### PR TITLE
[widget_filelog.js] code fixes ; new attributes

### DIFF
--- a/www/tablet/js/widget_filelog.js
+++ b/www/tablet/js/widget_filelog.js
@@ -8,43 +8,72 @@
 "use strict";
 
 /* Params:
- * 
- * data-device: 
- *   The name of the logfile device.
- *   The Event "linesInTheFile" is used to trigger an update. This has to be set manually in the FileLog.
- * 
+ *
+ * data-device:
+ *   The name of the FileLog device.
+ *   By default, the event "linesInTheFile" is used to trigger an update.
+ *   This event has to be activated manually in the FileLog device (attribute eventOnThreshold; example value 1).
+ *
  * data-ago:
- *   If set the the widget will load older entries. Default is 0.
- *   Time is given in Minutes.
- * 
- * max-items:
- *   If set, the display of old messages is limited to this number.
- *   Default is -1 (No maximum).
- * 
- * height:
+ *   Default=0. When set to a value >0, the widget will load older log lines.
+ *   Value/Time is given in Minutes.
+ *   Alternative value: today - means only log lines from today will be displayed
+ *
+ * data-max-items:
+ *   Default=-1, that means "no maximum". If set to a value >0, the display of log lines is limited to this number.
+ *
+ * data-height:
  *   Height of the widget.
- * 
- * width:
+ *
+ * data-width:
  *   Width of the widget.
- * 
- * refresh-btn:
+ *
+ * date-refresh-btn:
  *   Default=0. When activated (=1) there will be a refresh button displayed.
- * 
- * disable-update-event:
+ *
+ * data-disable-update-event:
  *   Default=0. When activated (=1) updates will be deactivated, even when the log emits 'linesInTheFile' events.
- * 
+ *
  * auto-update:
  *   Default=0. When set to a value >0, the widget will cyclic update the log. Intervall is in Seconds.
  *   NOT-IMPLEMENTED-YET
+ *
+ * data-substitution:
+ *
+ * data-newest-first:
+ *   Default=0. When activated (=1) the newest log line will be the first line; otherwise it'll be the latest line.
  */
- 
+
+/* FHEM Forum:
+ *
+ * https://forum.fhem.de/index.php/topic,63759.0.html
+ */
+
+/* History:
+ * 
+ * 2016-12-31
+ *   initial release
+ * 2018-12-30 by sinus61
+ *   - fixed csrf problem
+ *   - added data-substitution
+ * 2019-01-04 by sinus61
+ *   - fixed url problem
+ * 2019-03-10
+ *   - added data-newest-first
+ * 2019-04-17
+ *   - added data-ago="today"
+ * 2019-04-20
+ *   - removed class "events" (maybe paste and copy error in initial widget release / widget_eventmonitor.js)
+ *   - added class "filelog-lines" (valid for html-tag surrounding all the log lines)
+ *   - added class "filelog-line" (valid for html-tag surrounding one log line)
+ */
+
 function depends_filelog() {
     var deps = [];
     return deps;
 }
 
 var Modul_filelog = function () {
-	
     function init_attr(elem) {
         elem.initData('height', '150px');
         elem.initData('width', '400px');
@@ -52,72 +81,77 @@ var Modul_filelog = function () {
         elem.initData('get', 'linesInTheFile');
         elem.initData('refresh-btn', 0);
         elem.initData('disable-update-event', 0);
+        elem.initData('substitution', ''); //sinus61
+        elem.initData('newest-first', 0);
 
-		// Creation-time of Widget. 
+        // Creation-time of Widget. 
         elem.data('start-time', new Date()); 
-        
+
         if (elem.data('disable-update-event') === 0) {
-			me.addReading(elem, 'get');
-		}
+          me.addReading(elem, 'get');
+        }
     }
 
     function init_ui(elem) {
-
-        var content = elem.html();
-        elem.html('');
-        var starter = $('<div/>', {
-                class: 'eventmonitor-starter'
-            }).html(content)
-            .appendTo(elem);
-
-        var events = $('<div/>', {
-            class: 'events'
+        var lines = $('<div/>', {
+            class: 'filelog-lines'
         }).appendTo(elem);
-        
-        // Refresh Button.
-        if (elem.data('refresh-btn') == 1) {
-			var refresh = $('<div/>', {
-				class: ''
-			}).html('Refresh').appendTo(elem);
-			
-			// Refresh Event
-			refresh.on('click', function (e) {
-				me.refresh(elem);
-			});
-		}
-        
-        events.css({
+
+        lines.css({
             'height': elem.data('height'),
             'width': elem.data('width')
         });
-        
 
-		elem.data('elements', events);
-		
-		// If Update event is disabled, update at least once.
-		if (elem.data('disable-update-event') == 1) {
-			me.refresh(elem);
-		}
-	}
-	
-	function refresh(elem) {
+		    elem.data('elements', lines);
+
+        // Refresh Button.
+        if (elem.data('refresh-btn') == 1) {
+          var refresh = $('<div/>', {
+            class: ''
+          }).html('Refresh').appendTo(elem);
+
+          // Refresh Event
+          refresh.on('click', function (e) {
+            me.refresh(elem);
+          });
+        }
+
+		    // If Update event is disabled, update at least once.
+		    if (elem.data('disable-update-event') == 1) {
+			    me.refresh(elem);
+		    }
+	  }
+
+	  function refresh(elem) {
         var device = elem.attr('data-device') || '';
-        var reading = elem.attr('data-reading') || '';
 
-		// Calculation of Start and Endtime. Starttime is when widget was created!
-		var minutes = parseFloat(elem.attr('data-ago') || 0);
-		var now = new Date();
-        var ago = new Date();
-        var mindate = now;
-        var maxdate = now;
-        
-        ago = elem.data('start-time').addMinutes(-1 * minutes);
-        mindate = ago.yyyymmdd() + "_" + ago.hhmmss();
-        
-        maxdate.setDate(now.getDate() + 1);
-        maxdate = maxdate.yyyymmdd() + "_" + maxdate.hhmmss();
-        
-        // Get the entries from the FileLog.
+        // Calculation of Start and Endtime. Starttime is when widget was created!
+        if (elem.attr('data-ago') == "today") {
+          var timestamp = new Date();
+
+          var mindate = timestamp.yyyymmdd() + "_" + "00:00:00";
+          var maxdate = timestamp.yyyymmdd() + "_" + "23:59:59";
+        } else if (elem.attr('data-ago') == "yesterday") {
+          var today = new Date();
+          var yesterday = new Date(new Date().setDate(new Date().getDate()-1));
+
+          var mindate = yesterday.yyyymmdd() + "_" + "00:00:00";
+          var maxdate = today.yyyymmdd() + "_" + "23:59:59";
+        } else {
+          var minutes = parseFloat(elem.attr('data-ago') || 0);
+          var now = new Date();
+          var ago = new Date();
+          var mindate = now;
+          var maxdate = now;
+
+          ago = elem.data('start-time').addMinutes(-1 * minutes);
+          mindate = ago.yyyymmdd() + "_" + ago.hhmmss();
+
+          maxdate.setDate(now.getDate() + 1);
+          maxdate = maxdate.yyyymmdd() + "_" + maxdate.hhmmss();
+        }
+
+        // Get the entries from the FileLog device.
         var cmd = [
            'get',
            device,
@@ -128,7 +162,7 @@ var Modul_filelog = function () {
            ''
         ];
         $.ajax({
-            url: ftui.config.fhem_dir,
+            url: ftui.config.fhemDir,
             async: true,
             cache: false,
             context: {
@@ -136,44 +170,60 @@ var Modul_filelog = function () {
             },
             data: {
                 cmd: cmd.join(' '),
+                fwcsrf: ftui.config.csrf,
                 XHR: "1"
             },
         }).done(function (data) {
-            var lines = data.split('\n');
-            var events =  elem.data('elements');
+            var newLines = data.split('\n');
+            var lines =  elem.data('elements');
             var max = elem.data('max-items');
-            
-            // Remove old entries.
-			$.each(events.children(), function(index, value) {
-				value.remove();
-			});
-            
-            // Write new ones.
-            $.each(lines, function (index, value) {
-                if (value) {
-                    // Limit amount of entries -> Delete old entries which exceed the limit.
-                    if ((max > 0) && (events.children().length >= max))
-						events.find('.event:first').remove();
-						
-                    events.last().append("<div class='event'>" + value + "</div>");
-                }
-            });
-            
-            // Scroll to the end to show last entry.
-            events.scrollTop(events.last()[0].scrollHeight);
-        });
-    }
 
-    function update(dev, par) {
+            // Remove old entries.
+            $.each(lines.children(), function(index, value) {
+              value.remove();
+            });
+
+            // Add new entries.
+            if (elem.data('newest-first') === 1) {
+              var newLinesReversed = newLines.slice(0).reverse();
+
+              $.each(newLinesReversed, function (index, value) {
+                if (value) {
+                  if ((max > 0) && (lines.children().length >= max))
+						        return false;
+
+                  value = me.substitution(value, elem.data('substitution'));
+                  lines.last().append("<div class='filelog-line'>" + value + "</div>");
+                }
+              });
+            } else {
+              $.each(newLines, function (index, value) {
+                if (value) {
+                  // Limit amount of entries -> Delete old entries which exceed the limit.
+                  if ((max > 0) && (lines.children().length >= max))
+						        lines.find('.filelog-line:first').remove();
+
+                  value = me.substitution(value, elem.data('substitution'));
+                  lines.last().append("<div class='filelog-line'>" + value + "</div>");
+                }
+              });
+            
+              // Scroll to the end to show last entry.
+              lines.scrollTop(lines.last()[0].scrollHeight);
+            }
+        });
+      }
+
+      function update(dev, par) {
         me.elements.filterDeviceReading('get', dev, par)
             .each(function (index) {
                 refresh($(this));
             });
-    }
+      }
 
-    // public
-    // inherit members from base class
-    var me = $.extend(new Modul_widget(), {
+      // public
+      // inherit members from base class
+      var me = $.extend(new Modul_widget(), {
         //override members.
         widgetname: 'filelog',
         init_attr: init_attr,


### PR DESCRIPTION
- new attribute data-newest-first
- new value 'today' for attribute data-ago
- removed class 'events' (maybe paste and copy error in initial widget release)
- new auto-class 'filelog-lines' (valid for html-tag - surrounding all the log lines)
- new auto-class 'filelog-line' (valid for html-tag - surrounding one log line)